### PR TITLE
Build ABI3 wheels for all platforms

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -36,7 +36,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
-          CIBW_BUILD: "cp38-*"
+          CIBW_BUILD: "cp38-* cp39-win_arm64"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -36,6 +36,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+          CIBW_BUILD: "cp38-*"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -1,14 +1,14 @@
 name: Build and upload to PyPI
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request]
+# on: [push, pull_request]
 # Alternatively, to publish when a (published) GitHub Release is created, use the following:
-# on:
-#   push:
-#   pull_request:
-#   release:
-#     types:
-#       - published
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   build_wheels:
@@ -21,12 +21,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         env:
-          CIBW_ARCHS: auto64
+          CIBW_ARCHS: "x86_64 aarch64"
+          CIBW_ARCHS_MACOS: "universal2"
+          CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -38,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
 
       - name: Build sdist
         run: pipx run build --sdist
@@ -51,9 +60,9 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         env:
-          CIBW_ARCHS: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"

--- a/dds/dds_bindings.cpp
+++ b/dds/dds_bindings.cpp
@@ -82,7 +82,7 @@ static PyObject* dds_sys_decompress_with_crop(PyObject* self, PyObject* args) {
         return nullptr;
     }
 
-    auto* ret = (ImageHandleObject*)PyObject_NEW(ImageHandleObject, ImageHandleType);
+    auto* ret = (ImageHandleObject*)PyObject_New(ImageHandleObject, ImageHandleType);
     if (ret) {
         ret->img = img.release();
         return (PyObject*)ret;

--- a/dds/dds_bindings.cpp
+++ b/dds/dds_bindings.cpp
@@ -1,7 +1,146 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #include "process_image.hpp"
+
+struct ImageHandleObject {
+    PyObject_HEAD
+    Image* img;
+};
+
+static void ImageHandle_dealloc(ImageHandleObject* self) {
+    delete self->img;
+    self->img = nullptr;
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject* ImageHandle_extent(ImageHandleObject* self, void* closure) {
+    auto extent = self->img->extent;
+    return Py_BuildValue("ii", extent.x, extent.y);
+}
+
+static PyObject* ImageHandle_pixels(ImageHandleObject* self, void* closure) {
+    auto& pixels = self->img->data;
+    char const* data_ptr = reinterpret_cast<char const*>(pixels.data());
+    Py_ssize_t data_len = static_cast<Py_ssize_t>(pixels.size()) * self->img->components;
+    return Py_BuildValue("y#", data_ptr, data_len);
+}
+
+static PyMethodDef ImageHandle_methods[] = {
+    {"extent", (PyCFunction)ImageHandle_extent, METH_NOARGS, "image size in pixels"},
+    {"pixels", (PyCFunction)ImageHandle_pixels, METH_NOARGS, "raw image data"},
+    {nullptr},
+};
+
+static PyObject* ImageHandle_getcomponents(ImageHandleObject* self, void* closure) {
+    return PyLong_FromLong(self->img->components);
+}
+
+static PyGetSetDef ImageHandle_getsetters[] = {
+    {"components", (getter)ImageHandle_getcomponents, nullptr, "components per pixel", nullptr},
+    {nullptr},
+};
+
+static PyTypeObject ImageHandleType = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    .tp_name = "dds.ImageHandle",
+    .tp_doc = PyDoc_STR("Image handle"),
+    .tp_basicsize = sizeof(ImageHandleObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_dealloc = (destructor)ImageHandle_dealloc,
+    .tp_methods = ImageHandle_methods,
+    .tp_getset = ImageHandle_getsetters,
+};
+
+static PyObject* ImageHandle_create(PyTypeObject* type, PyObject* args) {
+    ImageHandleObject* self;
+    self = (ImageHandleObject*)type->tp_alloc(type, 0);
+    if (self) {
+        //  self->img = 
+    }
+    return nullptr;
+}
+
+static PyObject* dds_sys_decompress_with_crop(PyObject* self, PyObject* args) {
+    char const* src_data;
+    Py_ssize_t src_len;
+    PyObject* cropTuple{};
+
+    // Parse out the outer arguments.
+    if (!PyArg_ParseTuple(args, "y#O", &src_data, &src_len, &cropTuple)) {
+        return nullptr;
+    }
+
+    gsl::span srcSpan(reinterpret_cast<uint8_t const *>(src_data), static_cast<size_t>(src_len));
+    int x0, y0, w, h;
+    std::optional<Rect> cropRect;
+
+    // Pull apart the optional crop tuple if present.
+    if (cropTuple != Py_None) {
+        if (!PyArg_ParseTuple(cropTuple, "iiii", &x0, &y0, &w, &h)) {
+            return nullptr;
+        }
+        cropRect = Rect{gli::ivec2(x0, y0), gli::ivec2(w, h)};
+    }
+
+    std::unique_ptr<Image> img;
+    try {
+        img = ConvertCommand(srcSpan, cropRect);
+    } catch (std::runtime_error &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return nullptr;
+    }
+
+    auto* ret = (ImageHandleObject*)PyObject_NEW(ImageHandleObject, &ImageHandleType);
+    if (ret) {
+        ret->img = img.release();
+        return (PyObject*)ret;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef DdsSysMethods[] = {
+    {"decompress_with_crop", dds_sys_decompress_with_crop, METH_VARARGS, "Decode a DDS file with optional cropping."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+static char const* dds_sys_doc = PyDoc_STR("Bindings around Compressonator and image-process for DDS.");
+
+static struct PyModuleDef dds_sysmodule = {
+    PyModuleDef_HEAD_INIT,
+    "dds_sys",
+    dds_sys_doc,
+    -1,
+    DdsSysMethods,
+};
+
+PyMODINIT_FUNC
+PyInit_dds_sys(void) {
+    PyObject* m;
+    if (PyType_Ready(&ImageHandleType) < 0) {
+        return nullptr;
+    }
+
+    m = PyModule_Create(&dds_sysmodule);
+    if (!m) {
+        return nullptr;
+    }
+
+    Py_INCREF(&ImageHandleType);
+    if (PyModule_AddObject(m, "ImageHandle", (PyObject*)&ImageHandleType) < 0) {
+        Py_DECREF(&ImageHandleType);
+        Py_DECREF(m);
+        return nullptr;
+    }
+
+    return m;
+}
+
+#if 0
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -31,3 +170,4 @@ PYBIND11_MODULE(dds_sys, m) {
         },
         py::arg("src_data"), py::arg("crop") = py::none());
 }
+#endif

--- a/dds/dds_bindings.cpp
+++ b/dds/dds_bindings.cpp
@@ -3,6 +3,8 @@
 
 #include "process_image.hpp"
 
+#include <stdexcept>
+
 struct ImageHandleObject {
     PyObject_HEAD
     Image* img;

--- a/dds/process_image.cpp
+++ b/dds/process_image.cpp
@@ -21,7 +21,7 @@ struct ImageRef {
     gsl::span<uint8_t const> data;
 };
 
-std::shared_ptr<Image> ConvertCommand(gsl::span<uint8_t const> srcData, std::optional<Rect> cropOpt) {
+std::unique_ptr<Image> ConvertCommand(gsl::span<uint8_t const> srcData, std::optional<Rect> cropOpt) {
     auto tex = gli::load(reinterpret_cast<char const*>(srcData.data()), srcData.size());
     if (tex.empty()) {
         throw std::runtime_error(fmt::format("could not load texture"));
@@ -197,5 +197,5 @@ std::shared_ptr<Image> ConvertCommand(gsl::span<uint8_t const> srcData, std::opt
     }
 
     // At this point, we have R 8, RG 8.8, RGB 8.8.8 or RGBA 8.8.8.8 unsigned integer texture data
-    return std::make_shared<Image>(std::move(*dstImg));
+    return std::make_unique<Image>(std::move(*dstImg));
 }

--- a/dds/process_image.hpp
+++ b/dds/process_image.hpp
@@ -28,4 +28,4 @@ struct Image {
     std::vector<uint8_t> data;
 };
 
-std::shared_ptr<Image> ConvertCommand(gsl::span<uint8_t const> srcData, std::optional<Rect> crop);
+std::unique_ptr<Image> ConvertCommand(gsl::span<uint8_t const> srcData, std::optional<Rect> crop);

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ ext_modules = [
         sources=["dds/dds_bindings.cpp"] + cmp_core_sources + dds_sources,
         define_macros=[
             ("FMT_HEADER_ONLY", "1"),
-            ('Py_LIMITED_API', 0x03060000),
+            ('Py_LIMITED_API', 0x03080000),
         ],
         include_dirs=include_dirs,
         py_limited_api=True,

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ class build_ext_cxx17(build_ext):
         c = self.compiler.compiler_type
         if c == 'msvc':
             for e in self.extensions:
-                e.extra_compile_args = ['/std=c++latest']
+                e.extra_compile_args = ['/std:c++latest']
         else:
             for e in self.extensions:
                 e.extra_compile_args = ['-std=c++17']

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel
 
 cmp_core_sources = [
@@ -41,7 +42,6 @@ ext_modules = [
             ("FMT_HEADER_ONLY", "1"),
             ('Py_LIMITED_API', 0x03060000),
         ],
-        extra_compile_args=['-std=c++17'],
         include_dirs=include_dirs,
         py_limited_api=True,
     ),
@@ -60,6 +60,17 @@ class bdist_wheel_abi3(bdist_wheel):
 from pathlib import Path
 long_description = (Path(__file__).parent / "README.md").read_text()
 
+class build_ext_cxx17(build_ext):
+    def build_extensions(self):
+        c = self.compiler.compiler_type
+        if c == 'msvc':
+            for e in self.extensions:
+                e.extra_compile_args = ['/std=c++latest']
+        else:
+            for e in self.extensions:
+                e.extra_compile_args = ['-std=c++17']
+        build_ext.build_extensions(self)
+
 setup(
     name="pydds",
     version="0.0.5",
@@ -72,7 +83,10 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3 :: Only",
     ],
-    cmdclass={"bdist_wheel": bdist_wheel_abi3},
+    cmdclass={
+        "bdist_wheel": bdist_wheel_abi3,
+        "build_ext": build_ext_cxx17,
+    },
     ext_modules=ext_modules,
     install_requires=["Pillow"]
 )


### PR DESCRIPTION
ABI3 wheels with Python's Limited API allows us to build a single forward-compatible wheel per platform instead of the previous explosion of combinations.

This PR builds wheels based on Python 3.8 on all platforms but Windows ARM64 which has a minimum version of 3.9.